### PR TITLE
feat: add pagination to user-service and OpenAPI to auth-service

### DIFF
--- a/backend/auth-service/src/main/java/com/snapserve/auth/controller/AccountController.java
+++ b/backend/auth-service/src/main/java/com/snapserve/auth/controller/AccountController.java
@@ -6,6 +6,11 @@ import com.snapserve.auth.dto.RefreshTokenRequest;
 import com.snapserve.auth.dto.RegisterRequest;
 import com.snapserve.auth.service.AccountService;
 import com.snapserve.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,36 +22,85 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@Tag(name = "Authentication", description = "Authentication and authorization endpoints")
 public class AccountController {
   private final AccountService accountService;
 
   @PostMapping("/register")
+  @Operation(
+      summary = "Register a new user",
+      description = "Create a new customer or specialist account")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "201",
+        description = "User registered successfully"),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "409",
+        description = "User with this email already exists")
+  })
   public ResponseEntity<ApiResponse<Void>> register(@Valid @RequestBody RegisterRequest request) {
+    log.info("POST /api/v1/auth/register - Registering user");
     accountService.register(request);
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.ok("User registered successfully"));
   }
 
   @PostMapping("/login")
+  @Operation(
+      summary = "Login user",
+      description = "Authenticate user and return access/refresh tokens")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Login successful",
+        content = @Content(schema = @Schema(implementation = AuthResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "Invalid credentials")
+  })
   public ResponseEntity<ApiResponse<AuthResponse>> login(
       @Valid @RequestBody LoginRequest request,
       @RequestHeader(value = "X-Device-Id", defaultValue = "unknown") String deviceId,
       @RequestHeader(value = "X-Real-IP", defaultValue = "unknown") String ipAddress) {
+    log.info("POST /api/v1/auth/login - Login attempt");
     AuthResponse response = accountService.login(request, deviceId, ipAddress);
     return ResponseEntity.ok(ApiResponse.ok(response));
   }
 
   @PostMapping("/refresh")
+  @Operation(
+      summary = "Refresh access token",
+      description = "Use refresh token to get new access token")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Token refreshed successfully",
+        content = @Content(schema = @Schema(implementation = AuthResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "Invalid or expired refresh token")
+  })
   public ResponseEntity<ApiResponse<AuthResponse>> refreshAccessToken(
       @Valid @RequestBody RefreshTokenRequest request,
       @RequestHeader(value = "X-Device-Id", defaultValue = "unknown") String deviceId,
       @RequestHeader(value = "X-Real-IP", defaultValue = "unknown") String ipAddress) {
+    log.info("POST /api/v1/auth/refresh - Refreshing access token");
     AuthResponse response = accountService.refreshAccessToken(request, deviceId, ipAddress);
     return ResponseEntity.ok(ApiResponse.ok(response));
   }
 
   @PostMapping("/logout")
+  @Operation(summary = "Logout user", description = "Invalidate the refresh token")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Logged out successfully"),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "Invalid token")
+  })
   public ResponseEntity<ApiResponse<Void>> logout(@RequestBody RefreshTokenRequest request) {
+    log.info("POST /api/v1/auth/logout - Logging out user");
     accountService.logout(request.getRefreshToken());
     return ResponseEntity.ok(ApiResponse.ok("Logged out successfully"));
   }

--- a/backend/user-service-client/src/main/java/com/snapserve/userclient/dto/customer/CustomerListResponse.java
+++ b/backend/user-service-client/src/main/java/com/snapserve/userclient/dto/customer/CustomerListResponse.java
@@ -1,0 +1,12 @@
+package com.snapserve.userclient.dto.customer;
+
+import java.util.List;
+
+public record CustomerListResponse(
+    List<CustomerResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean first,
+    boolean last) {}

--- a/backend/user-service-client/src/main/java/com/snapserve/userclient/dto/specialist/SpecialistListResponse.java
+++ b/backend/user-service-client/src/main/java/com/snapserve/userclient/dto/specialist/SpecialistListResponse.java
@@ -1,0 +1,12 @@
+package com.snapserve.userclient.dto.specialist;
+
+import java.util.List;
+
+public record SpecialistListResponse(
+    List<SpecialistResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean first,
+    boolean last) {}

--- a/backend/user-service/src/main/java/com/snapserve/user/controller/CustomerController.java
+++ b/backend/user-service/src/main/java/com/snapserve/user/controller/CustomerController.java
@@ -2,15 +2,23 @@ package com.snapserve.user.controller;
 
 import com.snapserve.common.response.ApiResponse;
 import com.snapserve.user.service.UserService;
+import com.snapserve.userclient.dto.customer.CustomerListResponse;
 import com.snapserve.userclient.dto.customer.CustomerRequest;
 import com.snapserve.userclient.dto.customer.CustomerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +37,25 @@ public class CustomerController {
   public ResponseEntity<ApiResponse<List<CustomerResponse>>> getAllCustomers() {
     List<CustomerResponse> customers = userService.getAllCustomers();
     return ResponseEntity.ok(ApiResponse.ok(customers));
+  }
+
+  @GetMapping("/paged")
+  @Operation(
+      summary = "Get customers with pagination",
+      description = "Retrieve customers with pagination support")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Customers retrieved successfully",
+        content = @Content(schema = @Schema(implementation = CustomerListResponse.class)))
+  })
+  public ResponseEntity<ApiResponse<CustomerListResponse>> getCustomersPaged(
+      @ParameterObject
+          @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+    log.info("GET /api/v1/customers/paged - Fetching customers with pagination: {}", pageable);
+    CustomerListResponse customers = userService.getCustomers(pageable);
+    return ResponseEntity.ok(ApiResponse.ok("Customers retrieved successfully", customers));
   }
 
   @GetMapping("/{id}")

--- a/backend/user-service/src/main/java/com/snapserve/user/controller/SpecialistController.java
+++ b/backend/user-service/src/main/java/com/snapserve/user/controller/SpecialistController.java
@@ -2,15 +2,23 @@ package com.snapserve.user.controller;
 
 import com.snapserve.common.response.ApiResponse;
 import com.snapserve.user.service.UserService;
+import com.snapserve.userclient.dto.specialist.SpecialistListResponse;
 import com.snapserve.userclient.dto.specialist.SpecialistRequest;
 import com.snapserve.userclient.dto.specialist.SpecialistResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,6 +39,25 @@ public class SpecialistController {
     return ResponseEntity.ok(ApiResponse.ok(specialists));
   }
 
+  @GetMapping("/paged")
+  @Operation(
+      summary = "Get specialists with pagination",
+      description = "Retrieve specialists with pagination support")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Specialists retrieved successfully",
+        content = @Content(schema = @Schema(implementation = SpecialistListResponse.class)))
+  })
+  public ResponseEntity<ApiResponse<SpecialistListResponse>> getSpecialistsPaged(
+      @ParameterObject
+          @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+    log.info("GET /api/v1/specialists/paged - Fetching specialists with pagination: {}", pageable);
+    SpecialistListResponse specialists = userService.getSpecialists(pageable);
+    return ResponseEntity.ok(ApiResponse.ok("Specialists retrieved successfully", specialists));
+  }
+
   @GetMapping("/{id}")
   @Operation(
       summary = "Get specialist by ID",
@@ -49,6 +76,29 @@ public class SpecialistController {
       @Parameter(description = "Service name") @PathVariable String service) {
     List<SpecialistResponse> specialists = userService.getSpecialistsByService(service);
     return ResponseEntity.ok(ApiResponse.ok(specialists));
+  }
+
+  @GetMapping("/by-service/{service}/paged")
+  @Operation(
+      summary = "Get specialists by service with pagination",
+      description = "Retrieve specialists who provide a specific service with pagination")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Specialists retrieved successfully",
+        content = @Content(schema = @Schema(implementation = SpecialistListResponse.class)))
+  })
+  public ResponseEntity<ApiResponse<SpecialistListResponse>> getSpecialistsByServicePaged(
+      @Parameter(description = "Service name") @PathVariable String service,
+      @ParameterObject
+          @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+    log.info(
+        "GET /api/v1/specialists/by-service/{}/paged - Fetching specialists with pagination: {}",
+        service,
+        pageable);
+    SpecialistListResponse specialists = userService.getSpecialistsByService(service, pageable);
+    return ResponseEntity.ok(ApiResponse.ok("Specialists retrieved successfully", specialists));
   }
 
   @PostMapping

--- a/backend/user-service/src/main/java/com/snapserve/user/repo/UserRepository.java
+++ b/backend/user-service/src/main/java/com/snapserve/user/repo/UserRepository.java
@@ -5,6 +5,8 @@ import com.snapserve.user.model.UserEntity;
 import java.util.List;
 import java.util.Optional;
 import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface UserRepository extends MongoRepository<UserEntity, ObjectId> {
@@ -15,9 +17,13 @@ public interface UserRepository extends MongoRepository<UserEntity, ObjectId> {
 
   List<UserEntity> findByRole(Role role);
 
+  Page<UserEntity> findByRole(Role role, Pageable pageable);
+
   Optional<UserEntity> findByIdAndRole(ObjectId id, Role role);
 
   List<UserEntity> findByRoleAndServicesContaining(Role role, String service);
+
+  Page<UserEntity> findByRoleAndServicesContaining(Role role, String service, Pageable pageable);
 
   List<UserEntity> findByPhone(String phone);
 

--- a/backend/user-service/src/main/java/com/snapserve/user/service/UserService.java
+++ b/backend/user-service/src/main/java/com/snapserve/user/service/UserService.java
@@ -6,14 +6,18 @@ import com.snapserve.common.model.Role;
 import com.snapserve.user.mapper.UserMapper;
 import com.snapserve.user.model.UserEntity;
 import com.snapserve.user.repo.UserRepository;
+import com.snapserve.userclient.dto.customer.CustomerListResponse;
 import com.snapserve.userclient.dto.customer.CustomerRequest;
 import com.snapserve.userclient.dto.customer.CustomerResponse;
+import com.snapserve.userclient.dto.specialist.SpecialistListResponse;
 import com.snapserve.userclient.dto.specialist.SpecialistRequest;
 import com.snapserve.userclient.dto.specialist.SpecialistResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -59,10 +63,24 @@ public class UserService {
     return userMapper.toCustomerResponseList(customers);
   }
 
+  public CustomerListResponse getCustomers(Pageable pageable) {
+    log.debug("Fetching customers with pagination: {}", pageable);
+    Page<UserEntity> customerPage = userRepository.findByRole(Role.CUSTOMER, pageable);
+    log.debug("Found {} customers", customerPage.getTotalElements());
+    return toCustomerListResponse(customerPage);
+  }
+
   public List<SpecialistResponse> getAllSpecialists() {
     List<UserEntity> specialists = userRepository.findByRole(Role.SPECIALIST);
     log.debug("Found {} specialists", specialists.size());
     return userMapper.toSpecialistResponseList(specialists);
+  }
+
+  public SpecialistListResponse getSpecialists(Pageable pageable) {
+    log.debug("Fetching specialists with pagination: {}", pageable);
+    Page<UserEntity> specialistPage = userRepository.findByRole(Role.SPECIALIST, pageable);
+    log.debug("Found {} specialists", specialistPage.getTotalElements());
+    return toSpecialistListResponse(specialistPage);
   }
 
   public CustomerResponse getCustomerById(String id) {
@@ -88,6 +106,14 @@ public class UserService {
         userRepository.findByRoleAndServicesContaining(Role.SPECIALIST, service);
     log.debug("Found {} specialists with service: {}", specialists.size(), service);
     return userMapper.toSpecialistResponseList(specialists);
+  }
+
+  public SpecialistListResponse getSpecialistsByService(String service, Pageable pageable) {
+    log.debug("Fetching specialists by service: {} with pagination: {}", service, pageable);
+    Page<UserEntity> specialistPage =
+        userRepository.findByRoleAndServicesContaining(Role.SPECIALIST, service, pageable);
+    log.debug("Found {} specialists with service: {}", specialistPage.getTotalElements(), service);
+    return toSpecialistListResponse(specialistPage);
   }
 
   public CustomerResponse updateCustomer(String id, CustomerRequest request) {
@@ -157,5 +183,27 @@ public class UserService {
 
     userRepository.delete(specialist);
     log.info("Specialist deleted: {}", specialist.getEmail());
+  }
+
+  private CustomerListResponse toCustomerListResponse(Page<UserEntity> page) {
+    return new CustomerListResponse(
+        userMapper.toCustomerResponseList(page.getContent()),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.isFirst(),
+        page.isLast());
+  }
+
+  private SpecialistListResponse toSpecialistListResponse(Page<UserEntity> page) {
+    return new SpecialistListResponse(
+        userMapper.toSpecialistResponseList(page.getContent()),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.isFirst(),
+        page.isLast());
   }
 }


### PR DESCRIPTION
## Summary
- Add pagination support to user-service for customer and specialist endpoints
- Add OpenAPI/Swagger annotations to auth-service AccountController

## Changes

### Pagination (#2.11)
- Added paginated repository methods for `findByRole` and `findByRoleAndServicesContaining`
- Created `CustomerListResponse` and `SpecialistListResponse` DTOs
- Added paginated service methods and controller endpoints:
  - `GET /api/v1/customers/paged`
  - `GET /api/v1/specialists/paged`
  - `GET /api/v1/specialists/by-service/{service}/paged`

### OpenAPI Documentation (#2.10)
- Added `@Tag`, `@Operation`, and `@ApiResponses` annotations to auth-service AccountController
- Documented all endpoints: register, login, refresh, logout

## Testing
- ✅ Spotless format check passed
- ✅ Build passed (without tests)
- ✅ Tests passed

## Related Issues
Closes #2.11
Closes #2.10